### PR TITLE
fix: Constrain `UpdateLinkModel` to `MainActor`

### DIFF
--- a/Sources/Glitter/Models/UpdateLinkModel.swift
+++ b/Sources/Glitter/Models/UpdateLinkModel.swift
@@ -25,6 +25,7 @@ import SwiftUI
 import Sparkle
 
 // This view model class publishes when new updates can be checked by the user
+@MainActor
 final class UpdateLinkModel: ObservableObject {
     @Published var canCheckForUpdates = false
 


### PR DESCRIPTION
This is required for later SDKs and builds of Sparkle.